### PR TITLE
Remove clang-tidy warning about adding non-string types to string

### DIFF
--- a/MessengerOnFileForLinux/FileHandling/src/FileHandling.cpp
+++ b/MessengerOnFileForLinux/FileHandling/src/FileHandling.cpp
@@ -56,7 +56,7 @@ void waitForAccess(const std::string& folderName)
 
 std::unique_ptr<std::fstream> openFile(const std::string& pathToFile, FileMode mode, AccesMode accesMode = AccesMode::withGuardian)
 {
-    fileLog("FileInterface::openFile started in FileMode = " + static_cast<int>(mode), LogSpace::FileHandling);
+    fileLog(("FileInterface::openFile started in FileMode = " + std::to_string(static_cast<int>(mode))).c_str(), LogSpace::FileHandling);
     if (!FileInterface::Managment::isFileExist(pathToFile))
     {
         std::string logInfo = "FileInterface::openFile ERROR: " + pathToFile + " does not exist";

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.cpp
@@ -14,7 +14,7 @@ bool HistoryDowloander::doCommand()
     std::string systemCommand = "cp " + chatFileWithPath_ + " " + ENVIRONMENT_PATH::TO_FOLDER::USER;
     bool commandStatus = system(systemCommand.c_str());
 
-    std::string logData = "HistoryDowloander::doCommand() done as " + commandStatus;
+    std::string logData = "HistoryDowloander::doCommand() done as " + std::to_string(commandStatus);
     log_.function(logData);
     return commandStatus;
 }

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.cpp
@@ -14,7 +14,7 @@ bool LoggingOut::doCommand()
     bool commandStatus = false;
     commandStatus = signOutLocalUser.signOutUser();
 
-    std::string logData = "LoggingOut::doCommand() done as " + commandStatus;
+    std::string logData = "LoggingOut::doCommand() done as " + std::to_string(commandStatus);
     log_.function(logData);
     exit (EXIT_SUCCESS);
 }


### PR DESCRIPTION
In our logs sometimes we want to add information about status,
return value, mode etc. We have to add it to string (or c char *),
but we never explicit cast it. Now we do it..