### PR TITLE
Remove last clang-tidy error with garbage warning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,9 +59,8 @@ MWOZNIAK_CLANG_TIDY:
     - ./gcc_ci.sh 
     - cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/
     - python ../scripts/run-clang-tidy.py > /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
-    #TODO mnurzyns remove # after removing clang-tidy erros
-    #- cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/scripts/
-    #- bash check_clang-tidy_job_status.sh /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
+    - cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/scripts/
+    - bash check_clang-tidy_job_status.sh /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
   artifacts:
       when: always
       paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,9 +120,8 @@ MNURZYNS_CLANG_TIDY:
     - ./gcc_ci.sh 
     - cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/
     - python ../scripts/run-clang-tidy.py > /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
-    #TODO mnurzyns remove # after removing clang-tidy erros
-    #- cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/scripts/
-    #- bash check_clang-tidy_job_status.sh /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
+    - cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/scripts/
+    - bash check_clang-tidy_job_status.sh /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
   artifacts:
       when: always
       paths:
@@ -182,9 +181,8 @@ MASTER_CLANG_TIDY:
     - ./gcc_ci.sh 
     - cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/
     - python ../scripts/run-clang-tidy.py > /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
-    #TODO mnurzyns remove # after removing clang-tidy erros
-    #- cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/scripts/
-    #- bash check_clang-tidy_job_status.sh /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
+    - cd /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/scripts/
+    - bash check_clang-tidy_job_status.sh /builds/NMarcin/MessengerOnFileForLinux/MessengerOnFileForLinux/build/clangOutput.txt
   artifacts:
       when: always
       paths:

--- a/MessengerOnFileForLinux/ChatControl/src/Controler.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/Controler.hpp
@@ -12,6 +12,15 @@ class Controler
 public:
     void controlUserAction();
 
+    Controler() = default;
+    ~Controler() = default;
+
+    Controler(Controler &&) = delete;
+    Controler operator=(Controler &&) = delete;
+    Controler(const Controler &) = delete;
+    Controler operator=(const Controler &) = delete;
+
+
 private:
     std::unique_ptr<TerminalControl> terminalControl_;
     std::unique_ptr<ConversationControl> conversationControl_;

--- a/MessengerOnFileForLinux/ChatControl/src/ConversationControl.cpp
+++ b/MessengerOnFileForLinux/ChatControl/src/ConversationControl.cpp
@@ -110,11 +110,7 @@ bool ConversationControl::isMessagesToReadExist()
 
 void ConversationControl::handleInterlocutorInactivity()
 {
-<<<<<<< HEAD
-    std::call_once(userInactivityWasHandled_, [&]()
-=======
     if(not isUserInactivityWasHandled_)
->>>>>>> 8446c1fb043e1641222331defbf4852951c35176
     {
         markUserInactivityAsHandled();
         const std::string pathToChatFolder = *FileInterface::Accesor::getFolderName(chatInfo_->chatPath_);

--- a/MessengerOnFileForLinux/ChatControl/src/ConversationControl.cpp
+++ b/MessengerOnFileForLinux/ChatControl/src/ConversationControl.cpp
@@ -1,6 +1,5 @@
 #include <chrono>
 #include <thread>
-#include <mutex>
 #include <stdio.h>
 
 #include <ConversationControl.hpp>
@@ -13,7 +12,6 @@
 #include <ConsoleWindow.hpp>
 #include <PurgeMessage.hpp>
 
-std::once_flag userInactivityWasHandled;
 bool ConversationControl::isConversationRunning_ = false;
 
 ConversationControl::ConversationControl(std::shared_ptr<ChatInformation> chatInfo)
@@ -111,7 +109,7 @@ bool ConversationControl::isMessagesToReadExist()
 
 void ConversationControl::handleInterlocutorInactivity()
 {
-    std::call_once(userInactivityWasHandled, [&]()
+    std::call_once(userInactivityWasHandled_, [&]()
     {
         const std::string pathToChatFolder = *FileInterface::Accesor::getFolderName(chatInfo_->chatPath_);
         const std::string systemMessage = "Your interlocutor is inactive! You can leve chat";

--- a/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <queue>
 #include <ncurses.h>
+#include <mutex>
 
 #include <Sender.hpp>
 #include <Receiver.hpp>
@@ -50,6 +51,7 @@ private:
     std::queue<PurgeMessage> messageToDisplay_;
     bool isThreadsRunning_;
     UserInactivityDetector userInactivityDetector_;
+    std::once_flag userInactivityWasHandled_;
 
     Logger log_{LogSpace::ChatStarter};
 };

--- a/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
@@ -5,7 +5,6 @@
 #include <signal.h>
 #include <queue>
 #include <ncurses.h>
-#include <mutex>
 
 #include <Sender.hpp>
 #include <Receiver.hpp>
@@ -53,7 +52,6 @@ private:
     bool isThreadsRunning_;
     bool isUserInactivityWasHandled_;
     UserInactivityDetector userInactivityDetector_;
-    std::once_flag userInactivityWasHandled_;
 
     Logger log_{LogSpace::ChatStarter};
 };

--- a/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
@@ -19,8 +19,15 @@ class ConversationControl
 public:
     void conversation();
     void conversationEpilog();
+
     ConversationControl(std::shared_ptr<ChatInformation> chatInfo);
+    ConversationControl() = delete;
     ~ConversationControl();
+    ConversationControl(ConversationControl &&) = delete;
+    ConversationControl operator=(ConversationControl &&) = delete;
+    ConversationControl(const ConversationControl &) = delete;
+    ConversationControl operator=(const ConversationControl &) = delete;
+
     static bool isConversationRunning_;
 
 private:

--- a/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/ConversationControl.hpp
@@ -22,8 +22,8 @@ public:
     void conversationEpilog();
 
     ConversationControl(std::shared_ptr<ChatInformation> chatInfo);
-    ConversationControl() = delete;
     ~ConversationControl();
+
     ConversationControl(ConversationControl &&) = delete;
     ConversationControl operator=(ConversationControl &&) = delete;
     ConversationControl(const ConversationControl &) = delete;

--- a/MessengerOnFileForLinux/ChatControl/src/Receiver.cpp
+++ b/MessengerOnFileForLinux/ChatControl/src/Receiver.cpp
@@ -134,7 +134,7 @@ void Receiver::pushPurgeMessageOnStack(std::string rawMessageToPush)
 bool Receiver::updateSeenFlags()
 {
     log_.function("Receiver::updateSeenFlags() started");
-    bool updateFlagStatus;
+    bool updateFlagStatus = false;
     if(MessageFlag::inviterMessage == chatInfo_->messageFlag_)
     {
         log_.info("Receiver::updateSeenFlags() update flag status for MessageFlag::recipientMessage = 0");

--- a/MessengerOnFileForLinux/ChatControl/src/TerminalControl.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/TerminalControl.hpp
@@ -14,8 +14,8 @@ public:
     static void lookForInvitation();
 
     TerminalControl(ChatStatus chatStatus, std::shared_ptr<ChatInformation> chatInfo);
-    TerminalControl() = delete;
     ~TerminalControl() = default;
+
     TerminalControl(TerminalControl &&) = delete;
     TerminalControl operator=(TerminalControl &&) = delete;
     TerminalControl(const TerminalControl &) = delete;

--- a/MessengerOnFileForLinux/ChatControl/src/TerminalControl.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/TerminalControl.hpp
@@ -12,8 +12,15 @@ public:
     bool waitingInTerminal();
     bool startConversation(const std::string& username, ChatRole chatRole);
     static void lookForInvitation();
+
     TerminalControl(ChatStatus chatStatus, std::shared_ptr<ChatInformation> chatInfo);
+    TerminalControl() = delete;
     ~TerminalControl() = default;
+    TerminalControl(TerminalControl &&) = delete;
+    TerminalControl operator=(TerminalControl &&) = delete;
+    TerminalControl(const TerminalControl &) = delete;
+    TerminalControl operator=(const TerminalControl &) = delete;
+
     static bool isWaitingForInvitation;
     static bool isInvitationExist;
 


### PR DESCRIPTION
There was chance to return undeclarate value due to not enter to
if / else if. There was need for add default return value.