### PR TITLE
Add default / delete (rule 0/3/5) to classes

### DIFF
--- a/MessengerOnFileForLinux/ChatControl/src/Receiver.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/Receiver.hpp
@@ -16,6 +16,11 @@ public:
     Receiver(std::shared_ptr<ChatInformation> chatInfo);
     ~Receiver() = default;
 
+    Receiver(Receiver &&) = delete;
+    Receiver operator=(Receiver &&) = delete;
+    Receiver(const Receiver &) = delete;
+    Receiver operator=(const Receiver &) = delete;
+
     bool readMessagesToStack();
     std::unique_ptr<PurgeMessage> returnTheOldestMessage();
 

--- a/MessengerOnFileForLinux/ChatControl/src/Sender.cpp
+++ b/MessengerOnFileForLinux/ChatControl/src/Sender.cpp
@@ -14,11 +14,6 @@ Sender::Sender(std::shared_ptr<ChatInformation> chatInfo)
     log.info("Sender C-TOR");
 }
 
-Sender::~Sender()
-{
-    log.function("Sender D-TOR");
-}
-
 std::unique_ptr<Message> Sender::getMessageToSend() const
 {
     log.function("Sender::getMessageToSend() started");

--- a/MessengerOnFileForLinux/ChatControl/src/Sender.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/Sender.hpp
@@ -12,7 +12,12 @@ class Sender
 {
 public:
     Sender(std::shared_ptr<ChatInformation> chatInfo);
-    ~Sender();
+    ~Sender() = default;
+
+    Sender(Sender &&) = delete;
+    Sender operator=(Sender &&) = delete;
+    Sender(const Sender &) = delete;
+    Sender operator=(const Sender &) = delete;
 
     std::unique_ptr<Message> getMessageToSend() const;
     bool sendMessage(const Message& message) const;

--- a/MessengerOnFileForLinux/ChatControl/src/UserInactivityDetector.hpp
+++ b/MessengerOnFileForLinux/ChatControl/src/UserInactivityDetector.hpp
@@ -11,6 +11,11 @@ public:
     UserInactivityDetector(const std::string& username);
     ~UserInactivityDetector() = default;
 
+    UserInactivityDetector(UserInactivityDetector &&) = delete;
+    UserInactivityDetector operator=(UserInactivityDetector &&) = delete;
+    UserInactivityDetector(const UserInactivityDetector &) = delete;
+    UserInactivityDetector operator=(const UserInactivityDetector &) = delete;
+
     void detectUserInactivity();
     bool isUserInactiveDetected() const ;
 

--- a/MessengerOnFileForLinux/ChatStarter/src/ChatFabric.hpp
+++ b/MessengerOnFileForLinux/ChatStarter/src/ChatFabric.hpp
@@ -10,6 +10,11 @@ public:
     ChatFabric() = default;
     ~ChatFabric() = default;
 
+    ChatFabric(ChatFabric &&) = delete;
+    ChatFabric operator=(ChatFabric &&) = delete;
+    ChatFabric(const ChatFabric &) = delete;
+    ChatFabric operator=(const ChatFabric &) = delete;
+
     std::string createChatStructure(const std::string& usernameInviter, const std::string& usernameGuess) const;
 
 private:

--- a/MessengerOnFileForLinux/ChatStarter/src/ChatRequest.hpp
+++ b/MessengerOnFileForLinux/ChatStarter/src/ChatRequest.hpp
@@ -22,6 +22,11 @@ public:
     ChatRequest();
     ~ChatRequest();
 
+    ChatRequest(ChatRequest &&) = delete;
+    ChatRequest operator=(ChatRequest &&) = delete;
+    ChatRequest(const ChatRequest &) = delete;
+    ChatRequest operator=(const ChatRequest &) = delete;
+
 private:
     bool changeUserStatus(const User& user, const std::string& newStatus) const;
     std::unique_ptr<std::string> getChatFolderName(const std::string& folderName) const;

--- a/MessengerOnFileForLinux/DisplayChat/src/ChatWindow.cpp
+++ b/MessengerOnFileForLinux/DisplayChat/src/ChatWindow.cpp
@@ -3,16 +3,6 @@
 WINDOW* ChatWindow::displayMessageWindow_ = nullptr;
 WINDOW* ChatWindow::enterMessageWindow_ = nullptr;
 
-ChatWindow::ChatWindow()
-{
-    //NOOP
-}
-
-ChatWindow::~ChatWindow()
-{
-    //NOOP
-}
-
 void ChatWindow::displayChatWindows()
 {
     clear();

--- a/MessengerOnFileForLinux/DisplayChat/src/ChatWindow.hpp
+++ b/MessengerOnFileForLinux/DisplayChat/src/ChatWindow.hpp
@@ -9,8 +9,13 @@
 class ChatWindow
 {
 public:
-    ChatWindow();
-    ~ChatWindow();
+    ChatWindow() = default;
+    ~ChatWindow() = default;
+
+    ChatWindow(ChatWindow &&) = delete;
+    ChatWindow operator=(ChatWindow &&) = delete;
+    ChatWindow(const ChatWindow &) = delete;
+    ChatWindow operator=(const ChatWindow &) = delete;
 
     static void displayChatWindows();
     static void deleteDisplayMesageWindow();

--- a/MessengerOnFileForLinux/MessageFramework/src/Message.hpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/Message.hpp
@@ -23,6 +23,10 @@ public:
     Message(std::string messageFlag, std::string username, std::string content);
     Message(std::string fullMessageInRow);
     virtual ~Message() = default;
+    Message(Message &&) = default;
+    Message& operator=(Message &&) = default;
+    Message(const Message &) = default;
+    Message& operator=(const Message &) = default;
 
 protected:
     std::string time_;

--- a/MessengerOnFileForLinux/MessageFramework/src/PurgeMessage.hpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/PurgeMessage.hpp
@@ -9,6 +9,10 @@ public:
 
     PurgeMessage(const Message& message);
     ~PurgeMessage() = default;
+    PurgeMessage(PurgeMessage &&) = default;
+    PurgeMessage& operator=(PurgeMessage &&) = default;
+    PurgeMessage(const PurgeMessage &) = default;
+    PurgeMessage& operator=(const PurgeMessage &) = default;
 
 private:
     void setTime(std::string longTime);

--- a/MessengerOnFileForLinux/MessageFramework/src/StringSum.hpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/StringSum.hpp
@@ -9,6 +9,10 @@ class StringSumSquareBrackets
 public:
     StringSumSquareBrackets() = default;
     ~StringSumSquareBrackets() = default;
+    StringSumSquareBrackets(StringSumSquareBrackets &&) = default;
+    StringSumSquareBrackets& operator=(StringSumSquareBrackets &&) = default;
+    StringSumSquareBrackets(const StringSumSquareBrackets &) = default;
+    StringSumSquareBrackets& operator=(const StringSumSquareBrackets &) = default;
 
     void sum(std::string s);
     std::string getSumedString();

--- a/MessengerOnFileForLinux/UserService/src/RegisterUser.hpp
+++ b/MessengerOnFileForLinux/UserService/src/RegisterUser.hpp
@@ -12,6 +12,11 @@ public:
     RegisterUser();
     ~RegisterUser();
 
+    RegisterUser(RegisterUser &&) = delete;
+    RegisterUser operator=(RegisterUser &&) = delete;
+    RegisterUser(const RegisterUser &) = delete;
+    RegisterUser operator=(const RegisterUser &) = delete;
+
 private:
     std::unique_ptr<std::array<std::string, 2>> askUserForPassword() const;
     bool comparePasswords(std::array<std::string, 2> passwords) const;

--- a/MessengerOnFileForLinux/UserService/src/SignIn.hpp
+++ b/MessengerOnFileForLinux/UserService/src/SignIn.hpp
@@ -11,6 +11,11 @@ public:
     SignIn();
     ~SignIn();
 
+    SignIn(SignIn &&) = delete;
+    SignIn operator=(SignIn &&) = delete;
+    SignIn(const SignIn &) = delete;
+    SignIn operator=(const SignIn &) = delete;
+
 private:
     bool isUserLogged() const;
     bool isPasswordCorrect(const std::string& password, const std::string& correctPassword) const;

--- a/MessengerOnFileForLinux/UserService/src/SignOut.cpp
+++ b/MessengerOnFileForLinux/UserService/src/SignOut.cpp
@@ -4,16 +4,6 @@
 #include <LocalUser.hpp>
 
 
-SignOut::SignOut()
-{
-    log_.function("SignOut C-TOR");
-}
-
-SignOut::~SignOut()
-{
-    log_.function("SignOut D-TOR");
-}
-
 bool SignOut::signOutUser() const
 {
     log_.function("SignOut::signOutUser() started");

--- a/MessengerOnFileForLinux/UserService/src/SignOut.hpp
+++ b/MessengerOnFileForLinux/UserService/src/SignOut.hpp
@@ -7,12 +7,16 @@ class SignOut
 public:
     bool signOutUser() const;
 
-    SignOut();
-    ~SignOut();
+    SignOut() = default;
+    ~SignOut() = default;
+
+    SignOut(SignOut &&) = delete;
+    SignOut operator=(SignOut &&) = delete;
+    SignOut(const SignOut &) = delete;
+    SignOut operator=(const SignOut &) = delete;
 
 private:
     bool removeUserDataFromLoggedFile() const;
 
     Logger log_ {LogSpace::UserService};
 };
-


### PR DESCRIPTION
According to rule that we have think about all operators/ c-tor / d-tor
we add default / delete to them. In Sender d-tor (it should be in every
class's d-tor) I delete d-tor with log "Sender d-tor". Functionality of
this log will be moved to new Logger component.