### PR TITLE
Add delete/default in TerminalFunctionality module

### DIFF
--- a/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.cpp
@@ -9,11 +9,6 @@ EndConversation::EndConversation(std::string command, std::shared_ptr<ChatInform
     log_.function("EndConversation() C-TOR");
 }
 
-EndConversation::~EndConversation()
-{
-    log_.function("EndConversation() D-TOR");
-}
-
 bool EndConversation::doCommand()
 {
     log_.function("EndConversation::doCommand() start");

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.hpp
@@ -11,6 +11,11 @@ public:
     EndConversation(std::string command, std::shared_ptr<ChatInformation> chatInfo);
     ~EndConversation();
 
+    EndConversation(EndConversation &&) = delete;
+    EndConversation operator=(EndConversation &&) = delete;
+    EndConversation(const EndConversation &) = delete;
+    EndConversation operator=(const EndConversation &) = delete;
+
 private:
     std::shared_ptr<ChatInformation> chatInfo_;
     Logger log_ {LogSpace::TerminalFunctionality};

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.hpp
@@ -9,7 +9,7 @@ public:
     bool doCommand() override;
 
     EndConversation(std::string command, std::shared_ptr<ChatInformation> chatInfo);
-    ~EndConversation();
+    ~EndConversation() = default;
 
     EndConversation(EndConversation &&) = delete;
     EndConversation operator=(EndConversation &&) = delete;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.hpp
@@ -12,6 +12,12 @@ public:
     HistoryDowloander(std::string command, std::string chatFileWithPath);
     ~HistoryDowloander() = default;
 
+
+    HistoryDowloander(HistoryDowloander &&) = delete;
+    HistoryDowloander operator=(HistoryDowloander &&) = delete;
+    HistoryDowloander(const HistoryDowloander &) = delete;
+    HistoryDowloander operator=(const HistoryDowloander &) = delete;
+
 private:
     std::string chatFileWithPath_;
 

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.hpp
@@ -12,7 +12,6 @@ public:
     HistoryDowloander(std::string command, std::string chatFileWithPath);
     ~HistoryDowloander() = default;
 
-
     HistoryDowloander(HistoryDowloander &&) = delete;
     HistoryDowloander operator=(HistoryDowloander &&) = delete;
     HistoryDowloander(const HistoryDowloander &) = delete;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.cpp
@@ -11,11 +11,6 @@ InviteReceiver::InviteReceiver(std::string command, std::shared_ptr<ChatInformat
     log_.function("InviteReceiver() C-TOR");
 }
 
-InviteReceiver::~InviteReceiver()
-{
-    log_.function("InviteReceiver() D-TOR");
-}
-
 bool InviteReceiver::doCommand()
 {
     log_.function("InviteReceiver()::doCommand() started");

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.hpp
@@ -13,6 +13,11 @@ public:
     InviteReceiver(std::string command, std::shared_ptr<ChatInformation> chatInfo);
     ~InviteReceiver();
 
+    InviteReceiver(InviteReceiver &&) = delete;
+    InviteReceiver operator=(InviteReceiver &&) = delete;
+    InviteReceiver(const InviteReceiver &) = delete;
+    InviteReceiver operator=(const InviteReceiver &) = delete;
+
 private:
     std::string command_;
     std::shared_ptr<ChatInformation> chatInfo_;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.hpp
@@ -11,7 +11,7 @@ public:
     bool doCommand();
 
     InviteReceiver(std::string command, std::shared_ptr<ChatInformation> chatInfo);
-    ~InviteReceiver();
+    ~InviteReceiver() = default;
 
     InviteReceiver(InviteReceiver &&) = delete;
     InviteReceiver operator=(InviteReceiver &&) = delete;
@@ -23,4 +23,3 @@ private:
     std::shared_ptr<ChatInformation> chatInfo_;
     Logger log_ {LogSpace::TerminalFunctionality};
 };
-

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteSender.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteSender.hpp
@@ -13,6 +13,11 @@ public:
     InviteSender(std::string command, std::shared_ptr<ChatInformation> chatInfo);
     ~InviteSender();
 
+    InviteSender(InviteSender &&) = delete;
+    InviteSender operator=(InviteSender &&) = delete;
+    InviteSender(const InviteSender &) = delete;
+    InviteSender operator=(const InviteSender &) = delete;
+
 private:
     std::string command_;
     std::shared_ptr<ChatInformation> chatInfo_;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.hpp
@@ -12,6 +12,11 @@ public:
     LoggingOut(std::string command);
     ~LoggingOut() = default;
 
+    LoggingOut(LoggingOut &&) = delete;
+    LoggingOut operator=(LoggingOut &&) = delete;
+    LoggingOut(const LoggingOut &) = delete;
+    LoggingOut operator=(const LoggingOut &) = delete;
+
 private:
     Logger log_ {LogSpace::TerminalFunctionality};
 };

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalFunctionality.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalFunctionality.hpp
@@ -27,6 +27,11 @@ public:
     TerminalFunctionality() = default;
     ~TerminalFunctionality() = default;
 
+    TerminalFunctionality(TerminalFunctionality &&) = delete;
+    TerminalFunctionality operator=(TerminalFunctionality &&) = delete;
+    TerminalFunctionality(const TerminalFunctionality &) = delete;
+    TerminalFunctionality operator=(const TerminalFunctionality &) = delete;
+
 private:
     std::unique_ptr<TerminalCommand> terminalCommand_ = nullptr;
     std::string chatFileWithPath_;


### PR DESCRIPTION
Every terminal command should be single, we do not need
to copy or move it, because we want only cast it.