### PR TITLE
[FB_1904-4] Create empty fixture with dummy test.

### DIFF
--- a/MessengerOnFileForLinux/CMakeLists.txt
+++ b/MessengerOnFileForLinux/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(messenger_binary ${CURSES_LIBRARIES})
 include_directories(${CMAKE_SOURCE_DIR}/ChatStarter/test)
 include_directories(${CMAKE_SOURCE_DIR}/UserService/test)
 include_directories(${CMAKE_SOURCE_DIR}/MessageFramework/test)
+include_directories(${CMAKE_SOURCE_DIR}/TerminalFunctionality/test)
 # TEST
 add_subdirectory(main/test)
 add_subdirectory(FileHandling/test)
@@ -91,6 +92,7 @@ add_subdirectory(UserService/test)
 add_subdirectory(Common/test)
 add_subdirectory(ChatControl/test)
 add_subdirectory(MessageFramework/test)
+add_subdirectory(TerminalFunctionality/test)
 
 # CMAKE BUILD
 set(TEST_BINARY_FILES ${TEST_SOURCES} ${TEST_FILES} ${MAIN_TEST})

--- a/MessengerOnFileForLinux/MessageFramework/test/PurgeMessageTestCore.cpp
+++ b/MessengerOnFileForLinux/MessageFramework/test/PurgeMessageTestCore.cpp
@@ -1,5 +1,3 @@
-#include <thread>
-
 #include <PurgeMessageTestCore.hpp>
 
 void PurgeMessageFixture::SetUp()

--- a/MessengerOnFileForLinux/TerminalFunctionality/test/CMakeLists.txt
+++ b/MessengerOnFileForLinux/TerminalFunctionality/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+# TEST FILES WITH GTEST/GMOCK UNIT TESTS
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/TerminalFunctionalityTest.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TerminalFunctionalityTestCore.cpp PARENT_SCOPE)

--- a/MessengerOnFileForLinux/TerminalFunctionality/test/TerminalFunctionalityTest.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/test/TerminalFunctionalityTest.cpp
@@ -1,0 +1,6 @@
+#include <TerminalFunctionalityTestCore.hpp>
+
+TEST_F(TerminalFunctionalityFixture, isTrueisTrue)
+{
+    EXPECT_TRUE(true);
+}

--- a/MessengerOnFileForLinux/TerminalFunctionality/test/TerminalFunctionalityTestCore.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/test/TerminalFunctionalityTestCore.cpp
@@ -1,0 +1,21 @@
+#include <TerminalFunctionalityTestCore.hpp>
+
+TerminalFunctionalityFixture::TerminalFunctionalityFixture()
+{
+    // to implement
+}
+
+void TerminalFunctionalityFixture::SetUp()
+{
+    // to implement
+}
+
+void TerminalFunctionalityFixture::TearDown()
+{
+    // to implement
+}
+
+TerminalFunctionalityFixture::~TerminalFunctionalityFixture()
+{
+    // to implement
+}

--- a/MessengerOnFileForLinux/TerminalFunctionality/test/TerminalFunctionalityTestCore.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/test/TerminalFunctionalityTestCore.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <TerminalFunctionality.hpp>
+
+class TerminalFunctionalityFixture : public ::testing::Test
+{
+public:
+    TerminalFunctionalityFixture();;
+    void SetUp();
+    void TearDown();
+    ~TerminalFunctionalityFixture();
+};


### PR DESCRIPTION
Due to using mocks inside TerminalFunctionalityTests there is
need for create fixture which will create this mocks and handle
it - so there is created and plug in empty class.