### PR TITLE
[FB_1904-2] Add missing 'const' in classes

### DIFF
--- a/MessengerOnFileForLinux/Common/src/SignalHandling.hpp
+++ b/MessengerOnFileForLinux/Common/src/SignalHandling.hpp
@@ -3,15 +3,20 @@
 #include <stdlib.h>
 #include <array>
 
+namespace
+{
+static constexpr int NUMBER_OF_HANLING_POSIX_SIGNALS = 5;
+}
+
 namespace SignalHandling
 {
-     void posixSignalHandlerInMainConsole(int signal);
-     void posixSignalHandlerInChatConsole(int signal);
-     void createPosixSignalsHandling(void(*handlingFunction)(int));
+void posixSignalHandlerInMainConsole(int signal);
+void posixSignalHandlerInChatConsole(int signal);
+void createPosixSignalsHandling(void(*handlingFunction)(int));
 
-     static constexpr std::array<int, 6> posixSignalsCausingUnexpectedApplicationEndings{SIGINT,
-                                                                                    SIGHUP,
-                                                                                    SIGCONT,
-                                                                                    SIGTERM,
-                                                                                    0};
+static constexpr std::array<int, NUMBER_OF_HANLING_POSIX_SIGNALS> posixSignalsCausingUnexpectedApplicationEndings{SIGINT,
+                                                                                                                  SIGHUP,
+                                                                                                                  SIGCONT,
+                                                                                                                  SIGTERM,
+                                                                                                                  0};
 }

--- a/MessengerOnFileForLinux/Common/src/TimeManagment.hpp
+++ b/MessengerOnFileForLinux/Common/src/TimeManagment.hpp
@@ -5,9 +5,9 @@
 
 namespace TimeManagment
 {
-    using Time = std::chrono::system_clock;
+using Time = std::chrono::system_clock;
 
-    const std::tm* getLocalTime();
-    std::string convertTimeToString(const std::tm* time);
+const std::tm* getLocalTime();
+std::string convertTimeToString(const std::tm* time);
 
 }//TimeManagment

--- a/MessengerOnFileForLinux/Common/test/TimeManagmentTest.cpp
+++ b/MessengerOnFileForLinux/Common/test/TimeManagmentTest.cpp
@@ -16,14 +16,14 @@ const std::tm* getUnixEpochTime()
 
 TEST(ConvertTimeToString, TimeFormatSizeIsNineteen)
 {
-    constexpr int expectedTimeSize = 19;
+    static constexpr int expectedTimeSize = 19;
     const std::string timeAsString = TimeManagment::convertTimeToString(TimeManagment::getLocalTime());
 
     EXPECT_EQ(timeAsString.size(), expectedTimeSize);
 }
 
 TEST(ConvertTimeToString, TimeFormatIsCorrect)
-{   
+{
     const std::regex expectedTimeFormat("([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2})");
     std::smatch matcher;
     const auto unixEpochTimeAsString = TimeManagment::convertTimeToString(TimeManagment::getLocalTime());
@@ -32,7 +32,7 @@ TEST(ConvertTimeToString, TimeFormatIsCorrect)
 }
 
 TEST(ConvertTimeToString, TimeValueIsCorrect)
-{  
+{
     const std::string expectedTimeValue = "1970-01-01 00:00:00";
     const std::string unixEpochTimeAsString = TimeManagment::convertTimeToString(getUnixEpochTime());
 

--- a/MessengerOnFileForLinux/DisplayChat/src/ChatWindow.hpp
+++ b/MessengerOnFileForLinux/DisplayChat/src/ChatWindow.hpp
@@ -27,6 +27,4 @@ public:
 
     static WINDOW* displayMessageWindow_;
     static WINDOW* enterMessageWindow_;
-
-
 };

--- a/MessengerOnFileForLinux/MessageFramework/src/Message.cpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/Message.cpp
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-Message::Message(std::string messageFlag, std::string username, std::string content)
+Message::Message(const std::string& messageFlag, const std::string& username, const std::string& content)
 {
     log_.function("Message C-TOR string x3");
     setMessageFlag(messageFlag);
@@ -15,7 +15,7 @@ Message::Message(std::string messageFlag, std::string username, std::string cont
     time_ = TimeManagment::convertTimeToString(TimeManagment::getLocalTime());
 }
 
-Message::Message(std::string fullMessageInRow)
+Message::Message(const std::string& fullMessageInRow)
 {
     log_.function("Message C-TOR longString");
     messageFlag_.append( fullMessageInRow.begin() + 1,  fullMessageInRow.begin() + 2  );
@@ -37,8 +37,7 @@ std::string Message::messageToSave() const
     return fullMessage.getSumedString();
 }
 
-
-bool Message::setMessageFlag(std::string messageFlag)
+bool Message::setMessageFlag(const std::string& messageFlag)
 {
     log_.function("Message::setMessageFlag()");
     messageFlag_ = messageFlag;
@@ -60,7 +59,7 @@ bool Message::setMessageFlag(std::string messageFlag)
     }
 }
 
-bool Message::setContent(std::string content)
+bool Message::setContent(const std::string& content)
 {
     log_.function("Message::setContent()");
     int firstLetter = 1;

--- a/MessengerOnFileForLinux/MessageFramework/src/Message.hpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/Message.hpp
@@ -20,8 +20,8 @@ public:
     std::string getUsername() const;
     std::string getContent() const;
 
-    Message(std::string messageFlag, std::string username, std::string content);
-    Message(std::string fullMessageInRow);
+    Message(const std::string& messageFlag, const std::string& username, const std::string& content);
+    Message(const std::string& fullMessageInRow);
     virtual ~Message() = default;
     Message(Message &&) = default;
     Message& operator=(Message &&) = default;
@@ -36,8 +36,8 @@ protected:
     Message() = default;
 
 private:
-    bool setMessageFlag(std::string messageFlag);
-    bool setContent(std::string content);
+    bool setMessageFlag(const std::string& messageFlag);
+    bool setContent(const std::string& content);
 
     std::string messageFlag_;
 

--- a/MessengerOnFileForLinux/MessageFramework/src/PurgeMessage.cpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/PurgeMessage.cpp
@@ -27,7 +27,7 @@ PurgeMessage::PurgeMessage(const Message& message)
     content_ = message.getContent();
 }
 
-void PurgeMessage::setTime(std::string longTime)
+void PurgeMessage::setTime(const std::string& longTime)
 {
     log_.function("PurgeMessage::setTime() started");
     std::string logtime= "PurgeMessage::setTime() longTime = " + longTime;

--- a/MessengerOnFileForLinux/MessageFramework/src/PurgeMessage.hpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/PurgeMessage.hpp
@@ -15,7 +15,7 @@ public:
     PurgeMessage& operator=(const PurgeMessage &) = default;
 
 private:
-    void setTime(std::string longTime);
+    void setTime(const std::string& longTime);
 
 
     Logger log_ {LogSpace::MessageFramework};

--- a/MessengerOnFileForLinux/MessageFramework/src/StringSum.cpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/StringSum.cpp
@@ -2,14 +2,14 @@
 
 
 
-void StringSumSquareBrackets::sum(std::string s)
+void StringSumSquareBrackets::sum(const std::string& s)
 {
     std::string logSum = "StringSumSquareBrackets::sum() started with s = " + s;
     log_.function(logSum);
     sumedString += "[" + s + "]";
 }
 
-std::string StringSumSquareBrackets::getSumedString()
+std::string StringSumSquareBrackets::getSumedString() const
 {
     std::string logData = "StringSumSquareBrackets::getSumedString() sumedString ==" + sumedString;
     log_.info(logData);

--- a/MessengerOnFileForLinux/MessageFramework/src/StringSum.hpp
+++ b/MessengerOnFileForLinux/MessageFramework/src/StringSum.hpp
@@ -14,8 +14,8 @@ public:
     StringSumSquareBrackets(const StringSumSquareBrackets &) = default;
     StringSumSquareBrackets& operator=(const StringSumSquareBrackets &) = default;
 
-    void sum(std::string s);
-    std::string getSumedString();
+    void sum(const std::string& s);
+    std::string getSumedString() const;
 
 private:
     std::string sumedString;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.cpp
@@ -2,14 +2,14 @@
 #include <ConversationControl.hpp>
 #include <FileHandling.hpp>
 
-EndConversation::EndConversation(std::string command, std::shared_ptr<ChatInformation> chatInfo) :
-    TerminalCommand(command)
-  , chatInfo_(chatInfo)
+EndConversation::EndConversation(std::string command, std::shared_ptr<ChatInformation> chatInfo)
+    : TerminalCommand(command)
+    , chatInfo_(chatInfo)
 {
     log_.function("EndConversation() C-TOR");
 }
 
-bool EndConversation::doCommand()
+bool EndConversation::doCommand() const
 {
     log_.function("EndConversation::doCommand() start");
 

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/EndConversation.hpp
@@ -6,7 +6,7 @@
 class EndConversation : public TerminalCommand
 {
 public:
-    bool doCommand() override;
+    bool doCommand() const override;
 
     EndConversation(std::string command, std::shared_ptr<ChatInformation> chatInfo);
     ~EndConversation() = default;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.cpp
@@ -2,13 +2,13 @@
 #include <GlobalVariables.hpp>
 
 HistoryDowloander::HistoryDowloander(std::string command, std::string chatFileWithPath)
-                : TerminalCommand(command)
-                , chatFileWithPath_(chatFileWithPath)
+    : TerminalCommand(command)
+    , chatFileWithPath_(chatFileWithPath)
 {
     log_.function("HistoryDowloander() C-TOR");
 }
 
-bool HistoryDowloander::doCommand()
+bool HistoryDowloander::doCommand() const
 {
     log_.function("HistoryDowloander::doCommand()");
     std::string systemCommand = "cp " + chatFileWithPath_ + " " + ENVIRONMENT_PATH::TO_FOLDER::USER;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/HistoryDowloander.hpp
@@ -7,7 +7,7 @@
 class HistoryDowloander : public TerminalCommand
 {
 public:
-    bool doCommand() override;
+    bool doCommand() const override;
 
     HistoryDowloander(std::string command, std::string chatFileWithPath);
     ~HistoryDowloander() = default;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.cpp
@@ -3,15 +3,15 @@
 
 #include <ConversationControl.hpp>
 
-InviteReceiver::InviteReceiver(std::string command, std::shared_ptr<ChatInformation> chatInfo) :
-    TerminalCommand(command)
-  , command_(command)
-  , chatInfo_(chatInfo)
+InviteReceiver::InviteReceiver(std::string command, std::shared_ptr<ChatInformation> chatInfo)
+    : TerminalCommand(command)
+    , command_(command)
+    , chatInfo_(chatInfo)
 {
     log_.function("InviteReceiver() C-TOR");
 }
 
-bool InviteReceiver::doCommand()
+bool InviteReceiver::doCommand() const
 {
     log_.function("InviteReceiver()::doCommand() started");
     if (TerminalControl::isInvitationExist)

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteReceiver.hpp
@@ -8,7 +8,7 @@
 class InviteReceiver : public TerminalCommand
 {
 public:
-    bool doCommand();
+    bool doCommand() const override;
 
     InviteReceiver(std::string command, std::shared_ptr<ChatInformation> chatInfo);
     ~InviteReceiver() = default;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteSender.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteSender.cpp
@@ -3,10 +3,10 @@
 
 #include <ConversationControl.hpp>
 
-InviteSender::InviteSender(std::string command, std::shared_ptr<ChatInformation> chatInfo) :
-    TerminalCommand(command)
-  , command_(command)
-  , chatInfo_(chatInfo)
+InviteSender::InviteSender(std::string command, std::shared_ptr<ChatInformation> chatInfo)
+    : TerminalCommand(command)
+    , command_(command)
+    , chatInfo_(chatInfo)
 {
     log_.function("InviteSender() C-TOR");
 }
@@ -16,7 +16,7 @@ InviteSender::~InviteSender()
     log_.function("InviteSender() D-TOR");
 }
 
-bool InviteSender::doCommand()
+bool InviteSender::doCommand() const
 {
     log_.function("InviteSender()::doCommand() started");
 

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/InviteSender.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/InviteSender.hpp
@@ -8,7 +8,7 @@
 class InviteSender : public TerminalCommand
 {
 public:
-    bool doCommand();
+    bool doCommand() const;
 
     InviteSender(std::string command, std::shared_ptr<ChatInformation> chatInfo);
     ~InviteSender();
@@ -23,4 +23,3 @@ private:
     std::shared_ptr<ChatInformation> chatInfo_;
     Logger log_ {LogSpace::TerminalFunctionality};
 };
-

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.cpp
@@ -2,12 +2,12 @@
 #include <SignOut.hpp>
 
 LoggingOut::LoggingOut(std::string command)
-                : TerminalCommand(command)
+    : TerminalCommand(command)
 {
     log_.function("LoggingOut() C-TOR");
 }
 
-bool LoggingOut::doCommand()
+bool LoggingOut::doCommand() const
 {
     log_.function("LoggingOut::doCommand() started");
     SignOut signOutLocalUser;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/LoggingOut.hpp
@@ -7,7 +7,7 @@
 class LoggingOut : public TerminalCommand
 {
 public:
-    bool doCommand() override;
+    bool doCommand() const override;
 
     LoggingOut(std::string command);
     ~LoggingOut() = default;

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalCommand.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalCommand.cpp
@@ -1,7 +1,7 @@
 #include <TerminalCommand.hpp>
 
 TerminalCommand::TerminalCommand(std::string command)
-                : command_(command)
+    : command_(command)
 {
     //NOOP
 }

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalCommand.hpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalCommand.hpp
@@ -4,12 +4,12 @@
 class TerminalCommand
 {
 public:
-    virtual bool doCommand() = 0;
+    virtual bool doCommand() const = 0;
 
     TerminalCommand(std::string command);
     virtual ~TerminalCommand() = default;
 
 private:
-    std::string commandName_;
-    std::string command_;
+    const std::string commandName_;
+    const std::string command_;
 };

--- a/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalFunctionality.cpp
+++ b/MessengerOnFileForLinux/TerminalFunctionality/src/TerminalFunctionality.cpp
@@ -12,8 +12,17 @@
 #include <ConsoleWindow.hpp>
 #include <iostream>
 
-
+namespace
+{
 bool starts_with(const std::string toFind, const std::string ourString);
+}
+
+TerminalFunctionality::TerminalFunctionality(std::string chatFileWithPath, ChatStatus chatStatus)
+    : chatFileWithPath_(chatFileWithPath)
+    , chatStatus_(chatStatus)
+{
+    //NOOP
+}
 
 bool TerminalFunctionality::runCommand(std::string command, std::shared_ptr<ChatInformation> chatInfo)
 {
@@ -54,15 +63,8 @@ bool TerminalFunctionality::runCommand(std::string command, std::shared_ptr<Chat
     return terminalCommand_->doCommand();
 }
 
-TerminalFunctionality::TerminalFunctionality(std::string chatFileWithPath, ChatStatus chatStatus)
-            : chatFileWithPath_(chatFileWithPath)
-            , chatStatus_(chatStatus)
+namespace
 {
-    //NOOP
-}
-
-
-
 // waiting for GCC with C++20 support, function similar to it will be avaible in string class
 bool starts_with(const std::string starter, const std::string ourString)
 {
@@ -79,4 +81,5 @@ bool starts_with(const std::string starter, const std::string ourString)
         }
     }
     return true;
+}
 }

--- a/MessengerOnFileForLinux/UserService/src/RegisterUser.cpp
+++ b/MessengerOnFileForLinux/UserService/src/RegisterUser.cpp
@@ -93,7 +93,7 @@ bool RegisterUser::registerNewUser() const
         return false;
     }
 
-    constexpr int numberOfPasswordEntries = 2;
+    static constexpr int numberOfPasswordEntries = 2;
     std::array<std::string, numberOfPasswordEntries> providedPasswords;
     bool isPasswordSetCorrectly = false;
     while (!isPasswordSetCorrectly)


### PR DESCRIPTION
Due to rule that we always add const for methods which are not edditing
any atributes there was refactor in TerminalFunctionality and
MessageFramework modules. Other modules will be refactor later.