### PR TITLE
[FB_1904-1] Improvements in build_msg script

### DIFF
--- a/MessengerOnFileForLinux/CMakeLists.txt
+++ b/MessengerOnFileForLinux/CMakeLists.txt
@@ -18,6 +18,10 @@ include_directories(${CURSES_INCLUDE_DIR})
 include_directories(${GTEST_INCLUDE_DIRS})
 find_package(Curses REQUIRED)
 
+if(${GTEST_ONLY})
+    return()
+endif()
+
 ################################################################################
 #####                         MODULE DIR SOURCES                           #####
 ################################################################################
@@ -119,7 +123,7 @@ target_link_libraries(messenger_binary_UT ${CURSES_LIBRARIES}
 
 ################################################################################
 #####                      SET COMPILATION ORDER                           #####
-##### 1.source_objects_lib                                                     #####
+##### 1.source_objects_lib                                                 #####
 ##### 2.messenger_binary                                                   #####
 ##### 3.googletest                                                         #####
 ##### 4.messenger_binary_UT                                                #####

--- a/MessengerOnFileForLinux/scripts/local_scripts/build_msg
+++ b/MessengerOnFileForLinux/scripts/local_scripts/build_msg
@@ -1,16 +1,38 @@
 #!/bin/bash
 
-case $1 in
-  --cmake-only | -cm) cmake .. ;;
-  --make-only | -mk) make ;;
-  --clear | -cl) cd ../build; rm -rf *;;
-  --unit-test |-ut) cmake ..; make; ./bin/messenger_binary_UT;;	
-  --full | -f) cmake  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..; make; make valgrind; python ../scripts/local_scripts/run-clang-tidy.py ;;
-  --help | -h) 	echo '=== To use script go to */MessengerOnFileForLinux/build ===';
-	       	echo '-cm / --cmake-only -> generate only CMake files';
-	       	echo '-mk / --make-only  -> build without creating/updating CMake files';
-		echo '-cl / --clear      -> clear */build directory';
-		echo '-ut / --unit-test  -> build and run UT';
-		echo '-f  / --full       -> generate CMake files, build binary, run valgrind on UT and run clang-tidy';;
-  *) cmake ..; make
-esac
+if [ -z "$BUILD_PATH" ]; then
+    echo "Before use this script, you need set BUILD_PATH varaible in your system."
+    exit 1;
+fi
+
+if [ "$#" -ne 1 ]; then
+    cd $BUILD_PATH;
+    cmake ..; make
+fi
+
+for arg in "$@"
+    do
+	cd $BUILD_PATH;
+	case "$arg" in
+  	  --cmake-only | -cm) cmake .. ;;
+  	  --make-only | -mk) make ;;
+  	  --clang-tidy | -ct) cmake -DGTEST_ONLY=ON ..; make;\
+                              cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DGTEST_ONLY='' ..;\ 
+                              python ../scripts/local_scripts/run-clang-tidy.py ;;
+  	  --valgrind | -v) make valgrind ;;
+  	  --clear | -cl) rm -rf *;;
+  	  --unit-test |-ut) cmake ..; make; ./bin/messenger_binary_UT ;;	
+  	  --full | -f) cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..; make;\ 
+		       make valgrind;\ 
+		       python ../scripts/local_scripts/run-clang-tidy.py ;;
+  	  --help | -h) 	echo '=== To use script go to */MessengerOnFileForLinux/build ===';
+	       		echo '-cm / --cmake-only -> generate only CMake files';
+	       		echo '-mk / --make-only  -> build without creating/updating CMake files';
+			echo '-ct / --clang-tidy -> run clang-tidy code analysis';
+			echo '-v  / --valgrind   -> run valgrind on UT';
+			echo '-cl / --clear      -> clear */build directory';
+			echo '-ut / --unit-test  -> build and run UT';
+			echo '-f  / --full       -> generate CMake files, build binary, run valgrind on UT and run clang-tidy';;
+  	  *) echo "Unknown argumnt. Run script with -h / --help flag."
+	esac
+    done


### PR DESCRIPTION
Add valgrind and clang to script. Generation of clang-tidy analysis does not rebuild the entire project - only gtest repo is cloned. Also and the ability to use a script with multiple arguments